### PR TITLE
Bugfix: calculate set bonuses correctly after Tart update

### DIFF
--- a/topping_bot/cogs/cookies.py
+++ b/topping_bot/cogs/cookies.py
@@ -252,12 +252,12 @@ class Cookies(Cog, description="Optimize your cookies' toppings"):
 
                     await asyncio.sleep(2)
 
-                    if not cancelled and start_time + timedelta(minutes=40) < datetime.now():
+                    if not cancelled and start_time + timedelta(minutes=20) < datetime.now():
                         cancel_memory = SharedMemory(name=shared_memory.name)
                         cancel_memory.buf[-1] = 1
                         cancelled = True
 
-                    if cancelled and start_time + timedelta(minutes=42) < datetime.now():
+                    if cancelled and start_time + timedelta(minutes=22) < datetime.now():
                         process.terminate()
 
                 shared_memory.close()

--- a/topping_bot/optimize/optimize.py
+++ b/topping_bot/optimize/optimize.py
@@ -98,9 +98,11 @@ class Optimizer:
 
     def dfs(self, combo: List[Topping], idx):
         """Dfs combination generator, dfs so a benchmark solution is found as soon as possible"""
-        if len(combo) == 2:
+        if len(combo) == 1:
             # tqdm.write(f"{idx} : {combo[0]} : {self.key(combo[0])}")
-            yield combo[1]
+            yield combo[0]
+        if len(combo) == 2:
+            yield combo[:2]
         if (reason := self.prune(combo, self.toppings[idx:]))[0] != Prune.NONE:
             # tqdm.write(f"PRUNE : {reason} : {[str(topping) for topping in combo]}")
             return reason
@@ -124,11 +126,7 @@ class Optimizer:
 
     def prune(self, combo: List[Topping], toppings: List[Topping]):
         """Prune a combination subtree from consideration if it is unfavorable"""
-        failures = Prune.NONE
-
-        # length 1 means only tart topping
-        if(len(combo) == 1):
-            return failures, [], [], 0
+        failures = Prune.NONE 
         
         floor_failures = []
         overall_set_requirements = {}


### PR DESCRIPTION
Major bug introduced by commit related to Tart update: 7dd123eba0dc0ac21b853b35c000999a5dc163d1

Root cause:
The original algorithm for `best_possible_set_effect()` assumes that toppings will have EITHER 2 or 3-set effect, but never both to make some shortcuts. However, the new update makes it so that EVERY topping type has a 2/3/5/6-set effect.

Solution:
Change the solution to collect set bonuses for each type. Then calculate the maximum 2+3 set effect. 