### PR TITLE
Feature: allow user to download inventory csv

### DIFF
--- a/topping_bot/cogs/inventory.py
+++ b/topping_bot/cogs/inventory.py
@@ -528,3 +528,30 @@ class Inventory(Cog, description="View and update your topping inventory"):
                 "Use !inv help to learn more",
             ],
         )
+
+    @inv.command(aliases=[], brief="Download Inventory", description="Download your topping inventory")
+    async def download(self, ctx):
+        fp = DATA_PATH / f"{ctx.message.author.id}.csv"
+        if not fp.exists():
+            await send_msg(
+                ctx,
+                title="Err: No Topping Inventory",
+                description=[
+                    "You have not submitted a topping video.",
+                    "Please use !inv add <video> to update your inventory.",
+                    "Use !tutorial to learn more.",
+                ],
+            )
+            return
+        
+        embed = await new_embed(
+            title="Topping Inventory Download",
+            description=[
+                "Your topping inventory is ready for download",
+            ],
+        )
+
+        await ctx.reply(
+            embed=embed,
+            file=discord.File(fp, filename=f"{ctx.message.author.id}.csv")
+        )


### PR DESCRIPTION
Add command to export inventory csv data. It would be beneficial for users to have so that they can manually correct any toppings that were scanned incorrectly.

Note: after some discussion with yotta, we determined it would be unsafe to allow users to upload toppings. We will not support this action. For now, users must ask an admin to replace their file for them.